### PR TITLE
Use wildcard for JAR name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM arm64v8/eclipse-temurin:21-jre-alpine
 WORKDIR /workspace
-COPY build/libs/inventory-backend-0.0.1-beta.jar app.jar
+COPY build/libs/inventory-backend-*.jar app.jar
 ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
Previously the JAR name has been hard coded for rapid prototyping.